### PR TITLE
Add typescript example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,20 @@ To install on your website, insert Sa11y right before the closing </body> tag. S
 </script>
 ````
 
+### Example installation (Typescript)
+````typescript
+import { Sa11y, Lang, LangEn } from "sa11y";
+import CustomChecks from "path/to/your/custom-checks";
+import "sa11y/dist/css/sa11y.css";
+
+Lang.addI18n(LangEn.strings);
+const sa11y = new Sa11y({
+	customChecks: new CustomChecks, // Optional
+	checkRoot: "body",
+	readabilityRoot: "main",
+})
+````
+
 ### CDN
 Please visit [developer documentation](https://sa11y.netlify.app/developers/) for CDN installation instructions.
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ To install on your website, insert Sa11y right before the closing </body> tag. S
 
 ### Example installation (Typescript)
 ````typescript
+// src/your-script.ts
+
 import { Sa11y, Lang, LangEn } from "sa11y";
 import CustomChecks from "path/to/your/custom-checks";
 import "sa11y/dist/css/sa11y.css";

--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ To install on your website, insert Sa11y right before the closing </body> tag. S
 `npm i sa11y`
 
 ### Example installation (modules)
-````
+````html
 <!-- Stylesheet -->
 <link rel="stylesheet" href="css/sa11y.css"/>
 
-<!-- JavaScript >
+<!-- JavaScript -->
 <script type="module">
   import { Sa11y, Lang } from '../assets/js/sa11y.esm.js';
   import Sa11yLangEn from '../assets/js/lang/en.js';
@@ -56,7 +56,7 @@ To install on your website, insert Sa11y right before the closing </body> tag. S
 ````
 
 ### Example installation (regular script)
-````
+````html
 <!-- Stylesheet -->
 <link rel="stylesheet" href="css/sa11y.css"/>
 


### PR DESCRIPTION
With the recent additions of type declarations, I realized that there was no TS example in the readme, which would make sense since importing works slightly differently than the current examples.

### Proposed changes:
* Add typescript example to readme.md
* Specify language for all examples.