### PR TITLE
check for encoded URLs in same-page links

### DIFF
--- a/src/js/rulesets/quality-assurance.js
+++ b/src/js/rulesets/quality-assurance.js
@@ -59,7 +59,10 @@ export default function checkQA(results, option) {
       const hasText = $el.textContent.trim().length !== 0;
       if (option.inPageLinkQA && (href.startsWith('#') || href === '') && !hasButtonRole && hasText) {
         const targetId = href.substring(1);
-        const targetElement = document.getElementById(targetId);
+        let targetElement = false;
+        if(document.getElementById(targetId) || document.getElementById(decodeURIComponent(targetId))){
+          targetElement = true;
+        }
         if (!targetElement) {
           results.push({
             element: $el,


### PR DESCRIPTION
Hello! Thanks for all your work on this project - it's very popular here at Springer Nature 😄 there really was a huge gap in the market for a tool like this and I'm so glad you've filled it. 

One of our customer services advisors was using it on a support page generated by a third party vendor (Freshdesk). She found that Sa11y was triggering its broken same-page links rule because the 3rd party CMS was using encoded URIs in same page hrefs, but the associated IDs just used the plain text. 

This works fine in the browser, but because Sa11y is doing a straight string comparison, the "matching" IDs aren't getting picked up. This change adds an attempt to decode the URI too and see if that can get a match.  

I haven't added a unit test because I'm not familiar enough with Playwright, sorry! I pinky promise I've tested it offline though, and if you're willing to hold my hand a bit, I can add one for Playwright. 

[You can see an example of an affected page here](https://support.springernature.com/zh-CN/support/solutions/articles/6000230449-springer-nature%E4%BA%A7%E5%93%81#%E7%94%B5%E5%AD%90%E4%B9%A6%C2%A0). Our customer services folks are planning to update these pages soon, but I'm hoping it'll stay replicable for long enough for you to see what I mean - note the simplified Chinese characters in the IDs, and the encoded characters in the list of same page URLs at the top of the page. 

Thanks again! 