### PR TITLE
Fixed minor false negative

### DIFF
--- a/src/js/rulesets/images.js
+++ b/src/js/rulesets/images.js
@@ -37,7 +37,7 @@ export default function checkImages(results, option) {
     const susAltWordsOverride = (option.susAltStopWords) ? option.susAltStopWords.split(',').map((word) => word.trim()) : Lang._('SUS_ALT_STOPWORDS');
     susAltWordsOverride.forEach((word) => {
       const susWord = alt.toLowerCase().indexOf(word);
-      if (susWord > -1 && susWord < 6) {
+      if ((susWord > -1 && susWord < 6) || alt.toLowerCase().endsWith(word)) {
         hit[1] = word;
       }
     });

--- a/test/pages/unit-tests.html
+++ b/test/pages/unit-tests.html
@@ -135,6 +135,11 @@
       <img src="./assets/placeholder.svg" alt="A black and white image of a bird.">
     </div>
 
+    <h3>Alt text has suspicious stop word at the end</h3>
+    <div id="warning-alt-text-has-suspicious-stop-word-end">
+      <img src="./assets/placeholder.svg" alt="Large bird icon">
+    </div>
+
     <h3>Decorative image</h3>
     <div id="warning-image-is-decorative">
       <img src="./assets/placeholder.svg" alt>

--- a/test/unit-tests.spec.js
+++ b/test/unit-tests.spec.js
@@ -280,6 +280,13 @@ test.describe('Sa11y Unit Tests', () => {
     expect(issue).toBe(true);
   });
 
+  test('Alt text has suspicious stop word at the end', async () => {
+    const issue = await checkTooltip(
+      page, 'warning-alt-text-has-suspicious-stop-word', 'Assistive technologies already indicate that this is an image',
+    );
+    expect(issue).toBe(true);
+  });
+
   test('Decorative image', async () => {
     const issue = await checkTooltip(
       page, 'warning-image-is-decorative', 'Image is marked as <strong>decorative</strong>',


### PR DESCRIPTION
- Images with a suspicious stop word (image, icon, etc) at the end of alt text will now properly have a warning.
    - This only takes place when the stop word is at the exact _end_ of the alt text. Images with a stop word _near_ the end of the alt text still will not be flagged.
- Added a unit test to test suspicious stop words at the end of alt text.