### PR TITLE
Fix typos:

### DIFF
--- a/sandbox/dev.html
+++ b/sandbox/dev.html
@@ -255,7 +255,7 @@
     </svg>
 
     <hr>
-    <h2>Explicitely hidden button</h2>
+    <h2>Explicitly hidden button</h2>
     <button style="display:none"></button>
 
     <hr>
@@ -379,7 +379,7 @@
     <h2>Button with only role=none</h2>
     <div id="error-role-btn"><button role="none"></button></div>
 
-    <h2>Explicitely hidden button</h2>
+    <h2>Explicitly hidden button</h2>
     <div id="nothing-hidden-btn"><button style="display: none;"></button></div>
 
     <h2>Input type image with no accName</h2>
@@ -442,7 +442,7 @@
     <a href="https://google.com/somethings">Frugal</a> or <a href="https://google.com/somethings/asd"
       aria-label="frugal">Frugal</a>
     <hr>
-    <h2>Ignore seperators with low contrast</h2>
+    <h2>Ignore separators with low contrast</h2>
     <span class="separator" aria-hidden="true" style="color:hotpink">|</span>
     <br><br>
     <span class="separator" aria-hidden="true" style="color:hotpink">\</span>

--- a/src/js/utils/computeAccessibleName.js
+++ b/src/js/utils/computeAccessibleName.js
@@ -242,7 +242,7 @@ export const computeAccessibleName = (element, exclusions = [], recursing = 0) =
   // https://www.unicode.org/faq/private_use.html
   computedText = computedText.replace(/[\uE000-\uF8FF]/gu, '');
 
-  // If computedText returns blank, fallback on a) psuedo b) title attribute.
+  // If computedText returns blank, fallback on a) pseudo b) title attribute.
   if (!computedText.trim()) {
     computedText = wrapPseudoContent(element, '');
     if (!computedText.trim() && element.hasAttribute('title')) {


### PR DESCRIPTION
"Explicitely" to "Explicitly", "seperators" to "separators", and "psuedo" to "pseudo"