### PR TITLE
Allow disabling QA_PDF and/or QA_DOCUMENT

### DIFF
--- a/src/js/rulesets/link-text.js
+++ b/src/js/rulesets/link-text.js
@@ -371,20 +371,15 @@ export default function checkLinkText() {
     /* ************************************************************** */
     /*  Additional link checks previously from quality-assurance.js   */
     /* ************************************************************** */
-    const hasExtension = $el.matches(Constants.Global.documentSources);
-    const hasPDF = State.option.checks.QA_PDF?.sources
-      ? $el.matches(State.option.checks.QA_PDF.sources)
-      : $el.matches('a[href$=".pdf"], a[href*=".pdf?"]');
-
-    if (hasExtension) {
-      logResult({
-        test: 'QA_DOCUMENT',
+    if (Constants.Global.pdfSources && $el.matches(Constants.Global.pdfSources)) {
+        logResult({
+        test: 'QA_PDF',
         args: [linkText],
         dismissSuffix: href,
       });
-    } else if (hasPDF) {
+    } else if (Constants.Global.documentSources && $el.matches(Constants.Global.documentSources)) {
       logResult({
-        test: 'QA_PDF',
+        test: 'QA_DOCUMENT',
         args: [linkText],
         dismissSuffix: href,
       });

--- a/src/js/utils/constants.js
+++ b/src/js/utils/constants.js
@@ -33,13 +33,23 @@ const Constants = (function myConstants() {
       Global.html.getAttribute('dir')?.trim()?.toLowerCase() === 'rtl' ? 'rtl' : 'ltr';
 
     // Check for document types.
-    const documentSources = State.option.checks.QA_DOCUMENT.sources;
-    const defaultDocumentSources =
+    // Check for document types.    
+    if (State.option.checks.QA_DOCUMENT !== false) {
+      const defaultDocumentSources =
       'a[href$=".doc"], a[href$=".docx"], a[href*=".doc?"], a[href*=".docx?"], a[href$=".ppt"], a[href$=".pptx"], a[href*=".ppt?"], a[href*=".pptx?"], a[href^="https://drive.google.com/file"], a[href^="https://docs.google."], a[href^="https://sway."]';
-    if (documentSources) {
-      Global.documentSources = `${defaultDocumentSources}, ${documentSources}`;
+      Global.documentSources = State.option.checks.QA_DOCUMENT.sources
+        ? `${defaultDocumentSources}, ${State.option.checks.QA_DOCUMENT.sources}`
+        : defaultDocumentSources;
     } else {
-      Global.documentSources = defaultDocumentSources;
+      Global.documentSources = false;
+    }
+
+    if (State.option.checks.QA_PDF !== false) {
+      Global.pdfSources = State.option.checks.QA_PDF.sources
+        ? State.option.checks.QA_PDF.sources
+        : 'a[href$=".pdf"], a[href*=".pdf?"]';
+    } else {
+      Global.pdfSources = false;
     }
 
     /* ********************** */


### PR DESCRIPTION
1. Currently the code falls back to the default selectors and re-enables the test if 'sources' is not found in the check object, which includes situations where someone is trying to disable the test. This does an explicit test for `false` and passes the value through to the ruleset.
2. Moves building the PDF selector to CONSTANTS.
3. I also flipped the PDF/Document order, since the PDF match is usually a simpler query and PDF hits are more likely. I doubt the difference is perceptible except on pages with hundreds of PDFs, which I have seen in the wild.