### PR TITLE
Fix errors if MISSING_ALT is disabled

### DIFF
--- a/src/js/rulesets/images.js
+++ b/src/js/rulesets/images.js
@@ -98,9 +98,9 @@ export default function checkImages() {
     // Process link text exclusions.
     const linkText = link
       ? Utils.fnIgnore(link, Constants.Exclusions.LinkSpan).textContent.replace(
-          Constants.Global.linkIgnoreStringPattern,
-          '',
-        )
+        Constants.Global.linkIgnoreStringPattern,
+        '',
+      )
       : '';
     const linkTextLength = Utils.removeWhitespace(linkText).length;
 
@@ -134,7 +134,10 @@ export default function checkImages() {
         key = hasAria + src;
       }
     }
-    if (test && logResult({ test: test, dismiss: key })) return;
+    if (test) {
+      logResult({ test: test, dismiss: key });
+      return;
+    }
 
     // Continue if alt is presenting.
     const altText = Utils.removeWhitespace(alt);

--- a/src/js/utils/utils.js
+++ b/src/js/utils/utils.js
@@ -554,6 +554,7 @@ export function resetParentCache() {
  * @returns {string} String with line breaks and extra white space removed.
  */
 export function removeWhitespace(string) {
+  if (!string) return '';
   return string
     .replace(/[\r\n]+/g, ' ')
     .replace(/\s+/g, ' ')
@@ -1154,7 +1155,7 @@ export function validateLang(code, displayLangCode) {
   if (!langCache && typeof Intl !== 'undefined') {
     try {
       langCache = new Intl.DisplayNames([displayLangCode], { type: 'language', fallback: 'none' });
-    } catch {}
+    } catch { }
   }
 
   if (langCache) {


### PR DESCRIPTION
If MISSING_ALT is disabled, logResult for that test returns null, which causes the images ruleset to _continue_ and attempt to removeWhitespace on null.