### PR TITLE
Frame jumping breaks instanceOf

### DIFF
--- a/src/js/contrast/utils.js
+++ b/src/js/contrast/utils.js
@@ -72,7 +72,8 @@ export function getBackground($el, shadowDetection) {
     if (!node) return null;
     if (shadowDetection) {
       if (node.assignedSlot) return node.assignedSlot;
-      if (node instanceof ShadowRoot) return node.host;
+      // `instanceof ShadowRoot` is false across frames, so type + host.
+      if (node.nodeType === 11 && node.host) return node.host;
     }
     return node.parentElement || node.parentNode;
   };
@@ -83,7 +84,8 @@ export function getBackground($el, shadowDetection) {
   // Allow Node.ELEMENT_NODE (1) and Node.DOCUMENT_FRAGMENT_NODE / ShadowRoot (11).
   while (targetEl && (targetEl.nodeType === 1 || targetEl.nodeType === 11)) {
     // If we land exactly on a ShadowRoot, skip computing styles and jump to its host.
-    if (targetEl instanceof ShadowRoot) {
+    // `instanceof ShadowRoot` is false across frames, so type + host.
+    if (targetEl.nodeType === 11 && targetEl.host) {
       targetEl = targetEl.host;
       continue;
     }
@@ -108,7 +110,7 @@ export function getBackground($el, shadowDetection) {
         let parentBgColor = 'rgba(255, 255, 255, 1)'; // Default assumption
 
         while (parentEl && (parentEl.nodeType === 1 || parentEl.nodeType === 11)) {
-          if (parentEl instanceof ShadowRoot) {
+          if (parentEl.nodeType === 11 && parentEl.host) {
             parentEl = parentEl.host;
             continue;
           }

--- a/src/js/utils/elements.js
+++ b/src/js/utils/elements.js
@@ -82,7 +82,7 @@ const Elements = (function myElements() {
   function computePageText() {
     const elementSet = new Set(Found.Everything);
     return Found.Everything.filter(($el) => {
-      if ($el instanceof HTMLImageElement) return true;
+      if ($el.tagName === 'IMG') return true;
       // Prevent duplication: skip if any ancestor is also in the set.
       let parent = $el.parentElement;
       while (parent) {
@@ -93,7 +93,7 @@ const Elements = (function myElements() {
     })
       .map(($el) => {
         let text = '';
-        if ($el instanceof HTMLImageElement) {
+        if ($el.tagName === 'IMG') {
           text = $el.alt || '';
         } else if ($el.tagName === 'LI') {
           text = Array.from($el.childNodes)
@@ -188,9 +188,12 @@ const Elements = (function myElements() {
     // Iterate on Found.Everything based on tag name.
     for (let i = 0; i < Found.Everything.length; i++) {
       const $el = Found.Everything[i];
-      if ($el?.nodeType !== 1) continue;
-      const tag = $el?.tagName;
-      const role = $el?.getAttribute('role')?.trim().toLowerCase();
+      // Elements inside an iframed fixedRoot fail `instanceof Element`
+      // so we have to use exists + nodeType === 1 instead.
+      if (!$el || $el.nodeType !== 1) continue;
+
+      const tag = $el.tagName;
+      const role = $el.getAttribute('role')?.trim().toLowerCase();
       let handledByRole = false;
 
       // Role overrides.

--- a/src/js/utils/elements.js
+++ b/src/js/utils/elements.js
@@ -188,10 +188,7 @@ const Elements = (function myElements() {
     // Iterate on Found.Everything based on tag name.
     for (let i = 0; i < Found.Everything.length; i++) {
       const $el = Found.Everything[i];
-      // Elements inside an iframed fixedRoot fail `instanceof Element`
-      // so we have to use exists + nodeType === 1 instead.
       if (!$el || $el.nodeType !== 1) continue;
-
       const tag = $el.tagName;
       const role = $el.getAttribute('role')?.trim().toLowerCase();
       let handledByRole = false;

--- a/src/js/utils/find.js
+++ b/src/js/utils/find.js
@@ -14,8 +14,7 @@ export default function find(selector, desiredRoot, exclude) {
   if (desiredRoot === 'document') {
     root.push(document.body);
     if (State.option.fixedRoots) {
-      // fixedRoots are an array of objects with a fixedRoot and a positioner.
-      root.push(State.option.fixedRoots.map((entry) => entry?.fixedRoot).filter(Boolean));
+      root.push(State.option.fixedRoots);
     }
   } else if (desiredRoot === 'root') {
     root.push(Constants.Root.areaToCheck);

--- a/src/js/utils/find.js
+++ b/src/js/utils/find.js
@@ -14,7 +14,8 @@ export default function find(selector, desiredRoot, exclude) {
   if (desiredRoot === 'document') {
     root.push(document.body);
     if (State.option.fixedRoots) {
-      root.push(State.option.fixedRoots);
+      // fixedRoots are an array of objects with a fixedRoot and a positioner.
+      root.push(State.option.fixedRoots.map((entry) => entry?.fixedRoot).filter(Boolean));
     }
   } else if (desiredRoot === 'root') {
     root.push(Constants.Root.areaToCheck);

--- a/src/js/utils/utils.js
+++ b/src/js/utils/utils.js
@@ -534,8 +534,8 @@ let parentCache = new WeakMap();
  * @returns {Element|null} The matching parent or null.
  */
 export function getCachedClosest(element, selector) {
-  // Validate element.
-  if (!(element instanceof Element)) return null;
+  // Note: `instanceof Element` is unavailable across frames.
+  if (!element || element.nodeType !== 1) return null;
 
   // Validate selector.
   if (typeof selector !== 'string' || selector.trim() === '') return null;
@@ -1172,7 +1172,7 @@ export function validateLang(code, displayLangCode) {
   if (!langCache && typeof Intl !== 'undefined') {
     try {
       langCache = new Intl.DisplayNames([displayLangCode], { type: 'language', fallback: 'none' });
-    } catch {}
+    } catch { }
   }
 
   if (langCache) {


### PR DESCRIPTION
This is specific to live editing using fixedRoots across iframes: anything that checks against `instanceOf` returns `false` because the inner DOM nodes are not instances of anything in the wrapper page.

OMG debugging this stumped both me and Opus for hours. Stuff would just randomly not get detected in the iframe, even with identical DOM.